### PR TITLE
fix: Missing runTaskTimer delay validation for Folia

### DIFF
--- a/core/src/main/java/cn/superiormc/mythicprefixes/utils/SchedulerUtil.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/utils/SchedulerUtil.java
@@ -27,6 +27,27 @@ public class SchedulerUtil {
         }
     }
 
+    /**
+     * delay at least 1 ticks for Folia
+     */
+    private static long ensureValidDelay(long delayTicks) {
+        return delayTicks <= 0 ? 1 : delayTicks;
+    }
+
+    /**
+     * SchedulerUtil instance for Folia
+     */
+    private static SchedulerUtil createFoliaScheduler(ScheduledTask task) {
+        return new SchedulerUtil(task);
+    }
+
+    /**
+     * SchedulerUtil instance for Bukkit
+     */
+    private static SchedulerUtil createBukkitScheduler(BukkitTask task) {
+        return new SchedulerUtil(task);
+    }
+
     // 在主线程上运行任务
     public static void runSync(Runnable task) {
         if (MythicPrefixes.isFolia) {
@@ -48,34 +69,36 @@ public class SchedulerUtil {
     // 延迟执行任务
     public static SchedulerUtil runTaskLater(Runnable task, long delayTicks) {
         if (MythicPrefixes.isFolia) {
-            if (delayTicks <= 0) {
-                delayTicks = 1;
-            }
-            return new SchedulerUtil(Bukkit.getGlobalRegionScheduler().runDelayed(MythicPrefixes.instance,
-                    scheduledTask -> task.run(), delayTicks));
+            long validDelay = ensureValidDelay(delayTicks);
+            return createFoliaScheduler(Bukkit.getGlobalRegionScheduler().runDelayed(
+                MythicPrefixes.instance, scheduledTask -> task.run(), validDelay));
         } else {
-            return new SchedulerUtil(Bukkit.getScheduler().runTaskLater(MythicPrefixes.instance, task, delayTicks));
+            return createBukkitScheduler(Bukkit.getScheduler().runTaskLater(
+                MythicPrefixes.instance, task, delayTicks));
         }
     }
 
     // 定时循环任务
     public static SchedulerUtil runTaskTimer(Runnable task, long delayTicks, long periodTicks) {
         if (MythicPrefixes.isFolia) {
-            return new SchedulerUtil(Bukkit.getGlobalRegionScheduler().runAtFixedRate(MythicPrefixes.instance,
-                    scheduledTask -> task.run(), delayTicks, periodTicks));
+            long validDelay = ensureValidDelay(delayTicks);
+            return createFoliaScheduler(Bukkit.getGlobalRegionScheduler().runAtFixedRate(
+                MythicPrefixes.instance, scheduledTask -> task.run(), validDelay, periodTicks));
         } else {
-            return new SchedulerUtil(Bukkit.getScheduler().runTaskTimer(MythicPrefixes.instance, task, delayTicks, periodTicks));
+            return createBukkitScheduler(Bukkit.getScheduler().runTaskTimer(
+                MythicPrefixes.instance, task, delayTicks, periodTicks));
         }
     }
 
     // 延迟执行任务
     public static SchedulerUtil runTaskLaterAsynchronously(Runnable task, long delayTicks) {
         if (MythicPrefixes.isFolia) {
-            return new SchedulerUtil(Bukkit.getGlobalRegionScheduler().runDelayed(MythicPrefixes.instance,
-                    scheduledTask -> task.run(), delayTicks));
+            long validDelay = ensureValidDelay(delayTicks);
+            return createFoliaScheduler(Bukkit.getGlobalRegionScheduler().runDelayed(
+                MythicPrefixes.instance, scheduledTask -> task.run(), validDelay));
         } else {
-            return new SchedulerUtil(Bukkit.getScheduler().runTaskLaterAsynchronously(MythicPrefixes.instance, task, delayTicks));
+            return createBukkitScheduler(Bukkit.getScheduler().runTaskLaterAsynchronously(
+                MythicPrefixes.instance, task, delayTicks));
         }
     }
-
 }


### PR DESCRIPTION
When using command `/mythicprefixes opengui` got error but this pr it fixing that
```
[20:10:40 INFO]: [MythicPrefixes] Error: Your menu configs has wrong, error message: Initial delay ticks may not be <= 0                                                                                                                                                              
[20:10:40 WARN]: java.lang.IllegalArgumentException: Initial delay ticks may not be <= 0                                                                                                                                                                                              
[20:10:40 WARN]:        at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.runAtFixedRate(FoliaGlobalRegionScheduler.java:85)                                                                                                                                   
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.utils.SchedulerUtil.runTaskTimer(SchedulerUtil.java:64)                                                                                                                                             
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.objects.buttons.ObjectPrefix.runStartAction(ObjectPrefix.java:83)                                                                                                                                   
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.objects.ObjectCache.addActivePrefix(ObjectCache.java:81)                                                                                                                                            
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.objects.buttons.ObjectPrefix.clickEvent(ObjectPrefix.java:168)                                                                                                                                      
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.gui.inv.ChoosePrefixGUI.clickEventHandle(ChoosePrefixGUI.java:167)                                                                                                                                  
[20:10:40 WARN]:        at MythicPrefixes-1.7.1.jar//cn.superiormc.mythicprefixes.listeners.GUIListener.onClick(GUIListener.java:39)                                                                                                                                                  
```