### PR TITLE
Fix dynamic prefix boundary handling, concurrency, and transaction safety

### DIFF
--- a/core/src/main/java/cn/superiormc/mythicprefixes/commands/SubDynamicPrefix.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/commands/SubDynamicPrefix.java
@@ -55,6 +55,10 @@ public class SubDynamicPrefix extends AbstractCommand {
         }
         String playerUUID = args[2];
         String prefixID = args[3];
+        if (!isValidUUID(playerUUID)) {
+            LanguageManager.languageManager.sendStringText(sender, "error.args");
+            return;
+        }
         if (args[1].equalsIgnoreCase("approve")) {
             CacheManager.cacheManager.database.approveDynamicPrefixRequest(playerUUID, prefixID).thenAccept(success ->
                     SchedulerUtil.runSync(() -> afterHandle(sender, playerUUID, prefixID, success, true)));
@@ -82,6 +86,15 @@ public class SubDynamicPrefix extends AbstractCommand {
             LanguageManager.languageManager.sendStringText(sender, "dynamic-prefix.list-empty");
         }
         pendingRequestCache = cache;
+    }
+
+    private boolean isValidUUID(String value) {
+        try {
+            UUID.fromString(value);
+            return true;
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
     }
 
     private void afterHandle(Player sender, String playerUUID, String prefixID, boolean success, boolean approve) {

--- a/core/src/main/java/cn/superiormc/mythicprefixes/database/SQLDatabase.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/database/SQLDatabase.java
@@ -276,7 +276,9 @@ public class SQLDatabase extends AbstractDatabase {
 
     private CompletableFuture<Boolean> handleDynamicPrefixRequest(String playerUUID, String prefixID, boolean approve) {
         return CompletableFuture.supplyAsync(() -> {
-            try (Connection conn = dataSource.getConnection()) {
+            Connection conn = null;
+            try {
+                conn = dataSource.getConnection();
                 conn.setAutoCommit(false);
                 boolean exists;
                 try (PreparedStatement ps = conn.prepareStatement("""
@@ -322,7 +324,23 @@ public class SQLDatabase extends AbstractDatabase {
                 conn.commit();
                 return true;
             } catch (SQLException e) {
+                if (conn != null) {
+                    try {
+                        conn.rollback();
+                    } catch (SQLException rollbackEx) {
+                        rollbackEx.printStackTrace();
+                    }
+                }
                 e.printStackTrace();
+            } finally {
+                if (conn != null) {
+                    try {
+                        conn.setAutoCommit(true);
+                        conn.close();
+                    } catch (SQLException closeEx) {
+                        closeEx.printStackTrace();
+                    }
+                }
             }
             return false;
         }, DatabaseExecutor.EXECUTOR);

--- a/core/src/main/java/cn/superiormc/mythicprefixes/database/YamlDatabase.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/database/YamlDatabase.java
@@ -20,6 +20,8 @@ import java.util.concurrent.CompletableFuture;
 
 public class YamlDatabase extends AbstractDatabase {
 
+    private final Object pendingRequestLock = new Object();
+
     private final File dataDir = new File(MythicPrefixes.instance.getDataFolder(), "datas");
 
     private final File pendingFile = new File(dataDir, "pending-dynamic-prefixes.yml");
@@ -124,11 +126,13 @@ public class YamlDatabase extends AbstractDatabase {
             if (!dataDir.exists()) {
                 dataDir.mkdirs();
             }
-            YamlConfiguration config = loadPendingFile();
-            String path = "requests." + player.getUniqueId() + "." + prefixID;
-            config.set(path + ".playerName", player.getName());
-            config.set(path + ".value", value);
-            savePendingFile(config);
+            synchronized (pendingRequestLock) {
+                YamlConfiguration config = loadPendingFile();
+                String path = "requests." + player.getUniqueId() + "." + prefixID;
+                config.set(path + ".playerName", player.getName());
+                config.set(path + ".value", value);
+                savePendingFile(config);
+            }
             File file = new File(dataDir, player.getUniqueId() + ".yml");
             YamlConfiguration playerConfig = YamlConfiguration.loadConfiguration(file);
             ObjectCache cache = CacheManager.cacheManager.getPlayerCache(player);
@@ -143,7 +147,10 @@ public class YamlDatabase extends AbstractDatabase {
     public CompletableFuture<Collection<DynamicPrefixRequest>> getPendingDynamicPrefixRequests() {
         return CompletableFuture.supplyAsync(() -> {
             List<DynamicPrefixRequest> result = new ArrayList<>();
-            YamlConfiguration config = loadPendingFile();
+            YamlConfiguration config;
+            synchronized (pendingRequestLock) {
+                config = loadPendingFile();
+            }
             if (config.getConfigurationSection("requests") == null) {
                 return result;
             }
@@ -181,32 +188,35 @@ public class YamlDatabase extends AbstractDatabase {
 
     private CompletableFuture<Boolean> handleDynamicPrefixRequest(String playerUUID, String prefixID, boolean approve) {
         return CompletableFuture.supplyAsync(() -> {
-            YamlConfiguration pendingConfig = loadPendingFile();
-            String requestPath = "requests." + playerUUID + "." + prefixID;
-            String value = pendingConfig.getString(requestPath + ".value");
-            if (value == null) {
-                return false;
+            synchronized (pendingRequestLock) {
+                YamlConfiguration pendingConfig = loadPendingFile();
+                String requestPath = "requests." + playerUUID + "." + prefixID;
+                String value = pendingConfig.getString(requestPath + ".value");
+                if (value == null) {
+                    return false;
+                }
+                if (!dataDir.exists()) {
+                    dataDir.mkdirs();
+                }
+                File file = new File(dataDir, playerUUID + ".yml");
+                YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+                if (approve) {
+                    config.set("dynamic-prefix-values." + prefixID, ObjectCache.markDynamicPrefixApproved(value));
+                } else {
+                    String approvedValue = ObjectCache.parseApprovedDynamicPrefixValue(config.getString("dynamic-prefix-values." + prefixID));
+                    config.set("dynamic-prefix-values." + prefixID, ObjectCache.markDynamicPrefixDenied(approvedValue, value));
+                }
+                pendingConfig.set(requestPath, null);
+                try {
+                    config.save(file);
+                    savePendingFile(pendingConfig);
+                } catch (IOException e) {
+                    ErrorManager.errorManager.sendErrorMessage("\u00a7cError: Can not save data file: " + file.getName() + "!");
+                    return false;
+                }
+                return true;
             }
-            if (!dataDir.exists()) {
-                dataDir.mkdirs();
-            }
-            File file = new File(dataDir, playerUUID + ".yml");
-            YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
-            if (approve) {
-                config.set("dynamic-prefix-values." + prefixID, ObjectCache.markDynamicPrefixApproved(value));
-            } else {
-                String approvedValue = ObjectCache.parseApprovedDynamicPrefixValue(config.getString("dynamic-prefix-values." + prefixID));
-                config.set("dynamic-prefix-values." + prefixID, ObjectCache.markDynamicPrefixDenied(approvedValue, value));
-            }
-            pendingConfig.set(requestPath, null);
-            try {
-                config.save(file);
-                savePendingFile(pendingConfig);
-            } catch (IOException e) {
-                ErrorManager.errorManager.sendErrorMessage("\u00a7cError: Can not save data file: " + file.getName() + "!");
-                return false;
-            }
-            return true;
+            
         }, DatabaseExecutor.EXECUTOR);
     }
 

--- a/core/src/main/java/cn/superiormc/mythicprefixes/methods/DynamicPrefixes.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/methods/DynamicPrefixes.java
@@ -13,14 +13,14 @@ import cn.superiormc.mythicprefixes.utils.SchedulerUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.UUID;
 
 public class DynamicPrefixes {
 
-    private static final Map<UUID, ObjectPrefix> editingDynamicPrefixes = new HashMap<>();
+    private static final Map<UUID, ObjectPrefix> editingDynamicPrefixes = new ConcurrentHashMap<>();
 
     public static void openDynamicPrefixEditor(Player player, ObjectPrefix prefix) {
         if (!prefix.isDynamicPrefix()) {

--- a/core/src/main/java/cn/superiormc/mythicprefixes/objects/ObjectCache.java
+++ b/core/src/main/java/cn/superiormc/mythicprefixes/objects/ObjectCache.java
@@ -293,7 +293,7 @@ public class ObjectCache {
             return;
         }
         for (ObjectPrefix prefix : MythicPrefixesAPI.getActivedPrefixes(player)) {
-            if (prefix.isConditionNotMeet(this) || prefix.isConditionNotMeet(this)) {
+            if (prefix.isConditionNotMeet(this) || prefix.isDynamicPrefixEmpty(this)) {
                 removeActivePrefix(prefix, true);
             }
         }


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when admins pass malformed UUIDs to `/dynamicprefix approve|deny` by validating inputs before parsing. 
- Remove data-race and corruption windows where dynamic-prefix editor state and YAML pending-request files were concurrently accessed from async and sync threads. 
- Ensure SQL approval/deny flows do not leave transactions or connection state in an inconsistent state on error. 

### Description
- Add a `isValidUUID` check and early-return in `SubDynamicPrefix.execute(...)` to avoid `UUID.fromString` throwing on bad input, and keep `afterHandle` usage unchanged (file: `commands/SubDynamicPrefix.java`).
- Replace the editor tracking `HashMap` with a `ConcurrentHashMap` for `editingDynamicPrefixes` to make `put`/`remove`/`containsKey` safe across async chat and sync handlers (file: `methods/DynamicPrefixes.java`).
- Harden `SQLDatabase.handleDynamicPrefixRequest(...)` by obtaining a raw `Connection`, calling `conn.setAutoCommit(false)`, adding explicit `rollback()` on exceptions, and restoring `autoCommit` and closing the connection in `finally` to avoid leaking transactional state (file: `database/SQLDatabase.java`).
- Add a `private final Object pendingRequestLock` and wrap pending-request read-modify-write operations in `synchronized (pendingRequestLock)` in `YamlDatabase` to reduce lost updates when multiple threads submit/approve requests concurrently, including `saveDynamicPrefixRequest`, `getPendingDynamicPrefixRequests`, and `handleDynamicPrefixRequest` (file: `database/YamlDatabase.java`).
- Fix a duplicated condition check in `ObjectCache.checkCondition()` by changing the second redundant call to `isDynamicPrefixEmpty(...)` so active-prefix removal also triggers when a dynamic prefix becomes empty (file: `objects/ObjectCache.java`).

### Testing
- Attempted a Maven package build with `mvn -q -DskipTests package`, but the build failed due to external dependency resolution errors (403 from the Spigot snapshot repo), so no full project artifact was produced. 
- Local static checks and targeted searches (`rg`, `sed`) were used to verify the changed sites and ensure the intended code paths were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11098ba4148332b3c89e756b59ff82)